### PR TITLE
Add a check for sound input to stop random beepr sounds from playing

### DIFF
--- a/R/meowR.R
+++ b/R/meowR.R
@@ -18,6 +18,12 @@
 
 # function body
 meowR <- function(sound = 3) {
+  # If sound is out of range, give warning and play random sound
+  if(!(sound %in% 1:6)) {
+    message(glue::glue("Warning: There are currently only 6 sounds avaliable, you requested sound {sound}. Please see details in meowR help."))
+    message("Playing random meow")
+    sound <- sample(1:6, 1)
+  }
 
   # a vector of cat sounds
   sounds <- c(


### PR DESCRIPTION
This is to stop a random beepr sound from playing if the input given is greater than 6. This will still play a random sound and show a message rather than returning an error.